### PR TITLE
Do not block pg_upgrade (skip check when IsBinaryUpgrade)

### DIFF
--- a/safeupdate.c
+++ b/safeupdate.c
@@ -1,6 +1,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
 #include "parser/analyze.h"
 #include "utils/guc.h"
@@ -19,6 +20,9 @@ delete_needs_where_check(ParseState *pstate, Query *query, JumbleState *jstate)
 
 	if (prev_post_parse_analyze_hook != NULL)
 		(*prev_post_parse_analyze_hook)(pstate, query, jstate);
+
+	if (IsBinaryUpgrade)
+		return;
 
 	if (!safeupdate_enabled)
 		return;


### PR DESCRIPTION
Follow-up to #9, addressing problem 2 from #8.

pg_upgrade issues catalog UPDATEs without a WHERE clause — e.g. `UPDATE pg_catalog.pg_database SET datfrozenxid = …` — which safeupdate blocks, so the upgrade fails unless safeupdate is disabled first. These run while the server is in binary-upgrade mode, so skip the check when `IsBinaryUpgrade` is set. The previous hook is still called (just above), so other extensions keep working during the upgrade.

Verified: a plain PG17→PG18 `pg_upgrade` that fails with stock safeupdate (`UPDATE requires a WHERE clause`) completes with this change, safeupdate still enabled.

No automated test — exercising it needs a real `pg_upgrade` (two clusters), which doesn't fit the `pg_tmp` harness.

*Disclosure: I used an AI assistant to help investigate and draft this; I reproduced and verified it myself.*